### PR TITLE
Fix transport connection not being closed on error.

### DIFF
--- a/lib/transport.js
+++ b/lib/transport.js
@@ -59,26 +59,24 @@ Transport.doRequest = function(opts, body, fn) {
 
   // Define the request.
   var req = HTTPS.request(opts, function (response) {
-    // We accept only status codes from 200-399.
-    if (response.statusCode > 199 && response.statusCode < 400) {
-      //console.log(response.socket.getPeerCertificate());
-      var responseData = '';
-      response.on('data', function (bytes) {
-        responseData += bytes;
-      });
-      response.on('end', function() {
+    var responseData = '';
+    response.on('data', function(bytes) {
+      responseData += bytes;
+    });
+    response.on('end', function() {
+      // We accept only status codes from 200-399.
+      if (response.statusCode > 199 && response.statusCode < 400) {
         fn(false, response, responseData);
-      });
-      response.on('close', function (e) {
+      } else {
+        // console.log("FAILED with HTTP status code %d", response.statusCode);
+        var e = new Error('HTTP Error ' + response.statusCode);
+        e.statusCode = response.statusCode;
         fn(e);
-      });
-    }
-    else {
-      // console.log("FAILED with HTTP status code %d", response.statusCode);
-      var e = new Error('HTTP Error ' + response.statusCode);
-      e.statusCode = response.statusCode;
+      }
+    })
+    response.on('close', function (e) {
       fn(e);
-    }
+    });
   });
 
   // FIXME: Use better error handling.

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -171,24 +171,22 @@ Transport.doChunkedRequest = function (opts, stream, fn) {
 
   // Define the request.
   var req = HTTPS.request(opts, function (response) {
-
-    // We accept only status codes from 200-399.
-    if (response.statusCode > 199 && response.statusCode < 400) {
-      var responseData = '';
-      response.on('data', function (bytes) {
-        responseData += bytes;
-      });
-      response.on('end', function() {
+    var responseData = '';
+    response.on('data', function(bytes) {
+      responseData += bytes;
+    });
+    response.on('end', function() {
+      // We accept only status codes from 200-399.
+      if (response.statusCode > 199 && response.statusCode < 400) {
         var digestMD5 = md5.digest('hex');
         fn(false, response, responseData, digestMD5);
-      });
-    }
-    else {
-      console.log("FAILED with HTTP status code %d", response.statusCode);
-      var e = new Error('HTTP Error ' + response.statusCode);
-      e.statusCode = response.statusCode;
-      fn(e);
-    }
+      } else {
+        console.log("FAILED with HTTP status code %d", response.statusCode);
+        var e = new Error('HTTP Error ' + response.statusCode);
+        e.statusCode = response.statusCode;
+        fn(e);
+      }
+    });
   });
 
   if (Transport.debug) {


### PR DESCRIPTION
### To reproduce the problem:

Use the example code from the README.md file to try to authenticate. If your username/password/tenant ID are correct, everything works as expected.

If the auth details are wrong, the app doesn’t terminate for a long time.
### Cause:

The 'data' events were being ignored if there was an error. That left an outstanding HTTP connection that didn’t get released until the socket timed out.
### Fix:

Re-factored the transport code to always handle the 'data' and 'end' events. Check for bad HTTP statusCode in the 'end' event and proceed accordingly.
